### PR TITLE
Removing font-abeezee class from buttons in FontPicker.vue

### DIFF
--- a/src/FontPicker.vue
+++ b/src/FontPicker.vue
@@ -11,7 +11,7 @@
 			:class="{expanded: state.expanded}"
 			@scroll="onScroll">
 			<li v-for="font in fontManager.fonts" :key="font.family">
-				<button type="button" class="font-abeezee"
+				<button type="button"
 						:class="`font-${snakeCase(font.family)}${pickerSuffix} ${font.family === state.activeFont ? 'active-font' : ''}`"
 						@click="itemClick(font)"
 						@keypress="itemClick(font)">{{font.family}}</button>


### PR DESCRIPTION
Hello,

there is a font-abeezee class on all buttons inside the font picker panel, for each font, which does not make sense.

```
<ul class="expanded">
    <li>
          <button type="button" class="active-font font-abeezee font-cinzel">Cinzel</button>
    </li>
    <li>
        <button type="button" class="font-abeezee font-merriweather ">Merriweather</button>
    </li>
</ul>
```

this PR removes this class.

thanks.